### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-metaflow==2.6.3
+metaflow==2.7.18
 kubernetes


### PR DESCRIPTION
mt-wheat-hagberg issue comes from Pod metadata.name which is not caused either by the code, either by anyone. ArgoWorkflow has been updated multiple times lately and as the Metaflow release page says, new ArgoWorkflows instance does not like _ in functions name as it is used for pod names as concatenation with workflow name.

explanation model-deploymentxxxxx-StepName is ok as  model-deploymentxxxxx-init or model-deploymentxxxxx-start However model-deploymentxxxxx-check_input does not match the requirements of URI then pod is not created as this is the reason, we do have first message in slack for metaflow deployment but any thread replies which comes first with the check_input step function

@therealarty